### PR TITLE
Add master key ability and permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Note: In addition to being able to deploy locks directly, you can also use the f
 
 ### All locks
 
-- `vehicledeployedlocks.codelock.masterkey` -- Allows the player to open any lock managed by this plugin, useful for allowing admins access to locked vehicles.
+- `vehicledeployedlocks.masterkey` -- Allows the player to open any lock managed by this plugin, useful for allowing admins access to locked vehicles.
 
 ### Code Locks
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Note: In addition to being able to deploy locks directly, you can also use the f
 ### Code Locks
 
 - `vehicledeployedlocks.codelock.free` -- Allows the player to deploy code locks to vehicles without consuming locks or resources from their inventory.
+- `vehicledeployedlocks.codelock.masterkey` -- Allows the player to open any lock managed by this plugin, useful for allowing admins access to locked vehicles.
 
 The following permissions allow players to deploy code locks to vehicles.
 - `vehicledeployedlocks.codelock.allvehicles` (all in one)
@@ -47,6 +48,7 @@ The following permissions allow players to deploy code locks to vehicles.
 ### Key Locks
 
 - `vehicledeployedlocks.keylock.free` -- Allows the player to deploy key locks to vehicles without consuming locks or resources from their inventory.
+- `vehicledeployedlocks.keylock.masterkey` -- Allows the player to open any lock managed by this plugin, useful for allowing admins access to locked vehicles.
 
 The following permissions allow players to deploy key locks to vehicles.
 - `vehicledeployedlocks.keylock.allvehicles` (all in one)

--- a/README.md
+++ b/README.md
@@ -23,10 +23,13 @@ Note: In addition to being able to deploy locks directly, you can also use the f
 
 ## Permissions
 
+### All locks
+
+- `vehicledeployedlocks.codelock.masterkey` -- Allows the player to open any lock managed by this plugin, useful for allowing admins access to locked vehicles.
+
 ### Code Locks
 
 - `vehicledeployedlocks.codelock.free` -- Allows the player to deploy code locks to vehicles without consuming locks or resources from their inventory.
-- `vehicledeployedlocks.codelock.masterkey` -- Allows the player to open any lock managed by this plugin, useful for allowing admins access to locked vehicles.
 
 The following permissions allow players to deploy code locks to vehicles.
 - `vehicledeployedlocks.codelock.allvehicles` (all in one)
@@ -48,7 +51,6 @@ The following permissions allow players to deploy code locks to vehicles.
 ### Key Locks
 
 - `vehicledeployedlocks.keylock.free` -- Allows the player to deploy key locks to vehicles without consuming locks or resources from their inventory.
-- `vehicledeployedlocks.keylock.masterkey` -- Allows the player to open any lock managed by this plugin, useful for allowing admins access to locked vehicles.
 
 The following permissions allow players to deploy key locks to vehicles.
 - `vehicledeployedlocks.keylock.allvehicles` (all in one)

--- a/VehicleDeployedLocks.cs
+++ b/VehicleDeployedLocks.cs
@@ -8,7 +8,7 @@ using UnityEngine;
 
 namespace Oxide.Plugins
 {
-    [Info("Vehicle Deployed Locks", "WhiteThunder", "1.3.0")]
+    [Info("Vehicle Deployed Locks", "WhiteThunder", "1.4.0")]
     [Description("Allows players to deploy code locks and key locks to vehicles.")]
     internal class VehicleDeployedLocks : CovalencePlugin
     {
@@ -45,6 +45,7 @@ namespace Oxide.Plugins
 
             permission.RegisterPermission(LockInfo_CodeLock.PermissionFree, this);
             permission.RegisterPermission(LockInfo_CodeLock.PermissionAllVehicles, this);
+            permission.RegisterPermission(LockInfo_CodeLock.PermissionMasterKey, this);
             permission.RegisterPermission(VehicleInfo_Chinook.CodeLockPermission, this);
             permission.RegisterPermission(VehicleInfo_DuoSub.CodeLockPermission, this);
             permission.RegisterPermission(VehicleInfo_HotAirBalloon.CodeLockPermission, this);
@@ -62,6 +63,7 @@ namespace Oxide.Plugins
 
             permission.RegisterPermission(LockInfo_KeyLock.PermissionFree, this);
             permission.RegisterPermission(LockInfo_KeyLock.PermissionAllVehicles, this);
+            permission.RegisterPermission(LockInfo_KeyLock.PermissionMasterKey, this);
             permission.RegisterPermission(VehicleInfo_Chinook.KeyLockPermission, this);
             permission.RegisterPermission(VehicleInfo_DuoSub.KeyLockPermission, this);
             permission.RegisterPermission(VehicleInfo_HotAirBalloon.KeyLockPermission, this);
@@ -350,6 +352,22 @@ namespace Oxide.Plugins
         private bool IsPlayerAuthorizedToLock(BasePlayer player, BaseLock baseLock) =>
             (baseLock as KeyLock)?.HasLockPermission(player) ?? IsPlayerAuthorizedToCodeLock(player.userID, baseLock as CodeLock);
 
+        private bool PlayerHasMasterKeyForLock(BasePlayer player, BaseLock baseLock)
+        {
+            if (baseLock is KeyLock && permission.UserHasPermission(player.UserIDString, LockInfo_KeyLock.PermissionMasterKey))
+            {
+                return true;
+            }
+            else if (baseLock is CodeLock && permission.UserHasPermission(player.UserIDString, LockInfo_CodeLock.PermissionMasterKey))
+            {
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
         private bool IsLockSharedWithPlayer(BasePlayer player, BaseLock baseLock)
         {
             var ownerID = baseLock.OwnerID;
@@ -394,7 +412,8 @@ namespace Oxide.Plugins
                 return (bool)hookResult;
 
             return IsPlayerAuthorizedToLock(player, baseLock)
-                || IsLockSharedWithPlayer(player, baseLock);
+                || IsLockSharedWithPlayer(player, baseLock)
+                || PlayerHasMasterKeyForLock(player, baseLock);
         }
 
         private bool? CanPlayerInteractWithVehicle(BasePlayer player, BaseEntity vehicle, bool provideFeedback = true)
@@ -1031,6 +1050,7 @@ namespace Oxide.Plugins
             public string Prefab;
             public string PermissionAllVehicles;
             public string PermissionFree;
+            public string PermissionMasterKey;
             public string PreHookName;
 
             public ItemDefinition ItemDefinition =>
@@ -1046,6 +1066,7 @@ namespace Oxide.Plugins
             Prefab = "assets/prefabs/locks/keypad/lock.code.prefab",
             PermissionAllVehicles = $"{Permission_CodeLock_Prefix}.allvehicles",
             PermissionFree = $"{Permission_CodeLock_Prefix}.free",
+            PermissionMasterKey = $"{Permission_CodeLock_Prefix}.masterkey",
             PreHookName = "CanDeployVehicleCodeLock",
         };
 
@@ -1055,6 +1076,7 @@ namespace Oxide.Plugins
             Prefab = "assets/prefabs/locks/keylock/lock.key.prefab",
             PermissionAllVehicles = $"{Permission_KeyLock_Prefix}.allvehicles",
             PermissionFree = $"{Permission_KeyLock_Prefix}.free",
+            PermissionMasterKey = $"{Permission_KeyLock_Prefix}.masterkey",
             PreHookName = "CanDeployVehicleKeyLock",
         };
 

--- a/VehicleDeployedLocks.cs
+++ b/VehicleDeployedLocks.cs
@@ -19,6 +19,7 @@ namespace Oxide.Plugins
 
         private const string Permission_CodeLock_Prefix = "vehicledeployedlocks.codelock";
         private const string Permission_KeyLock_Prefix = "vehicledeployedlocks.keylock";
+        private const string Permission_MasterKey = "vehicledeployedlocks.masterkey";
 
         private const string Prefab_CodeLock_DeployedEffect = "assets/prefabs/locks/keypad/effects/lock-code-deploy.prefab";
         private const string Prefab_CodeLock_DeniedEffect = "assets/prefabs/locks/keypad/effects/lock.code.denied.prefab";
@@ -45,7 +46,6 @@ namespace Oxide.Plugins
 
             permission.RegisterPermission(LockInfo_CodeLock.PermissionFree, this);
             permission.RegisterPermission(LockInfo_CodeLock.PermissionAllVehicles, this);
-            permission.RegisterPermission(LockInfo_CodeLock.PermissionMasterKey, this);
             permission.RegisterPermission(VehicleInfo_Chinook.CodeLockPermission, this);
             permission.RegisterPermission(VehicleInfo_DuoSub.CodeLockPermission, this);
             permission.RegisterPermission(VehicleInfo_HotAirBalloon.CodeLockPermission, this);
@@ -63,7 +63,6 @@ namespace Oxide.Plugins
 
             permission.RegisterPermission(LockInfo_KeyLock.PermissionFree, this);
             permission.RegisterPermission(LockInfo_KeyLock.PermissionAllVehicles, this);
-            permission.RegisterPermission(LockInfo_KeyLock.PermissionMasterKey, this);
             permission.RegisterPermission(VehicleInfo_Chinook.KeyLockPermission, this);
             permission.RegisterPermission(VehicleInfo_DuoSub.KeyLockPermission, this);
             permission.RegisterPermission(VehicleInfo_HotAirBalloon.KeyLockPermission, this);
@@ -78,6 +77,8 @@ namespace Oxide.Plugins
             permission.RegisterPermission(VehicleInfo_Sedan.KeyLockPermission, this);
             permission.RegisterPermission(VehicleInfo_SoloSub.KeyLockPermission, this);
             permission.RegisterPermission(VehicleInfo_Workcart.KeyLockPermission, this);
+
+            permission.RegisterPermission(Permission_MasterKey, this);
 
             _craftKeyLockCooldowns = new CooldownManager(_pluginConfig.CraftCooldownSeconds);
             _craftCodeLockCooldowns = new CooldownManager(_pluginConfig.CraftCooldownSeconds);
@@ -354,18 +355,7 @@ namespace Oxide.Plugins
 
         private bool PlayerHasMasterKeyForLock(BasePlayer player, BaseLock baseLock)
         {
-            if (baseLock is KeyLock && permission.UserHasPermission(player.UserIDString, LockInfo_KeyLock.PermissionMasterKey))
-            {
-                return true;
-            }
-            else if (baseLock is CodeLock && permission.UserHasPermission(player.UserIDString, LockInfo_CodeLock.PermissionMasterKey))
-            {
-                return true;
-            }
-            else
-            {
-                return false;
-            }
+            return permission.UserHasPermission(player.UserIDString, Permission_MasterKey);
         }
 
         private bool IsLockSharedWithPlayer(BasePlayer player, BaseLock baseLock)
@@ -841,7 +831,7 @@ namespace Oxide.Plugins
         }
 
         #endregion
-
+            
         #region Vehicle Info
 
         private class VehicleInfo
@@ -1050,7 +1040,6 @@ namespace Oxide.Plugins
             public string Prefab;
             public string PermissionAllVehicles;
             public string PermissionFree;
-            public string PermissionMasterKey;
             public string PreHookName;
 
             public ItemDefinition ItemDefinition =>
@@ -1066,7 +1055,6 @@ namespace Oxide.Plugins
             Prefab = "assets/prefabs/locks/keypad/lock.code.prefab",
             PermissionAllVehicles = $"{Permission_CodeLock_Prefix}.allvehicles",
             PermissionFree = $"{Permission_CodeLock_Prefix}.free",
-            PermissionMasterKey = $"{Permission_CodeLock_Prefix}.masterkey",
             PreHookName = "CanDeployVehicleCodeLock",
         };
 
@@ -1076,7 +1064,6 @@ namespace Oxide.Plugins
             Prefab = "assets/prefabs/locks/keylock/lock.key.prefab",
             PermissionAllVehicles = $"{Permission_KeyLock_Prefix}.allvehicles",
             PermissionFree = $"{Permission_KeyLock_Prefix}.free",
-            PermissionMasterKey = $"{Permission_KeyLock_Prefix}.masterkey",
             PreHookName = "CanDeployVehicleKeyLock",
         };
 

--- a/VehicleDeployedLocks.cs
+++ b/VehicleDeployedLocks.cs
@@ -831,7 +831,7 @@ namespace Oxide.Plugins
         }
 
         #endregion
-            
+
         #region Vehicle Info
 
         private class VehicleInfo


### PR DESCRIPTION
This changeset adds a master key permission for key locks and code locks placed by the plugin. When granted the permission, players will be able to bypass any lock placed by the plugin. This is intended for admins to use to bypass the locks when investigating issues or resolving disputes.

As requested in [this thread](https://umod.org/community/vehicle-deployed-locks/36950-admin-master-key-permission).